### PR TITLE
fix format-truncation on 64bit

### DIFF
--- a/Release/src/http/common/http_helpers.cpp
+++ b/Release/src/http/common/http_helpers.cpp
@@ -88,7 +88,7 @@ size_t chunked_encoding::add_chunked_delimiters(_Out_writes_(buffer_size) uint8_
 #ifdef _WIN32
         sprintf_s(buffer, sizeof(buffer), "%8IX", bytes_read);
 #else
-        snprintf(buffer, sizeof(buffer), "%8zX", bytes_read);
+        snprintf(buffer, sizeof(buffer), "%8X", static_cast<std::uint32_t>(bytes_read));
 #endif
         memcpy(&data[0], buffer, 8);
         while (data[offset] == ' ')


### PR DESCRIPTION
GCC 10.x rightfully complains about out-of-bounds snprintf operation
on 64bit systems, where size_t could be 64bit sized.
Cast bytes_read down to 32bit and printf it without specifying input
format

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>